### PR TITLE
Add dependencies to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,8 @@ classifiers = [
     "Topic :: System :: Software Distribution",
 ]
 dependencies = [
-    # Note: zstd support is required but package name varies:
-    # - pip: zstandard
-    # - Mageia: python3-zstd (provides 'zstd' module)
-    # We don't list it here to avoid conflicts on Mageia
+  "solv",
+  "zstandard"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
These dependencies list the Python names, not the distro package names,
so they are distribution agnostic.