### PR TITLE
Clean up RPM dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Topic :: System :: Software Distribution",
 ]
 dependencies = [
+  "pygobject",
+  "rpm",
   "solv",
   "zstandard"
 ]

--- a/rpmbuild/SPECS/urpm-ng.spec
+++ b/rpmbuild/SPECS/urpm-ng.spec
@@ -15,22 +15,19 @@ Source1:        pk-backend-urpm.tar.gz
 # Note: No BuildArch:noarch because we also build the C backend
 
 # Python build requirements
+BuildRequires:  meson
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
-BuildRequires:  python3-wheel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-solv
-BuildRequires:  python3-rpm
-BuildRequires:  python3-zstandard
-BuildRequires:  meson
+BuildRequires:  python3dist(pygobject)
+BuildRequires:  python3dist(rpm)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(solv)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(zstandard)
 
-Requires:       python3
-Requires:       python3-solv
-Requires:       python3-rpm
-Requires:       python3-zstandard
-Requires:       python3-gobject
 Requires:       gnupg2
 Requires:       polkit
+Requires:       python3-gobject
 
 Requires(post):   systemd
 Requires(preun):  systemd


### PR DESCRIPTION
Remove redundant Requires: that are automatically generated and use the
automatic ones for BuildRequires: to make them more generic.  The
python3-gobject package doesn't provide a dependency so that must stay.